### PR TITLE
Fix Apple Logo for Mac OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ![Docker](https://img.shields.io/badge/-Docker-black?style=flat-square&logo=docker)&nbsp;
 ![IntelliJ](https://img.shields.io/badge/-IntelliJ%20IDEA-black?style=flat-square&logo=jetbrains)&nbsp;
 ![AWS](https://img.shields.io/badge/AWS-black?&logo=Amazon-AWS&logoColor=F90)&nbsp;
-![Mac OS](https://img.shields.io/badge/Mac%20OS-black?style=flat-square&logo=mac)&nbsp;
+![Mac OS](https://img.shields.io/badge/Mac%20OS-black?style=flat-square&logo=apple)&nbsp;
 ![Linux](https://img.shields.io/badge/Linux-black?style=flat-square&logo=linux)&nbsp;
 ![Splunk](https://img.shields.io/badge/Splunk-black?style=flat-square&logo=splunk)&nbsp;
 


### PR DESCRIPTION
Shields.io, the service making the badges, supports the icons at https://simpleicons.org natively. It doesn't look like there is one for `mac`, but there is one for `apple`.

(Or if you want to go super crazy you can actually specify your own base64 encoded string for any png/SVG and it will render it. `?logo=data:image/png;base64,…` but that's _alot_ of work so I stick with simple icons.)